### PR TITLE
Register IEntityMapper in DI so that instantiated Controller can use it

### DIFF
--- a/PropertyInformationApi/Startup.cs
+++ b/PropertyInformationApi/Startup.cs
@@ -110,6 +110,7 @@ namespace PropertyInformationApi
             ConfigureDbContext(services);
             RegisterGateways(services);
             RegisterUseCases(services);
+            ConfigurePropertyFactory(services);
         }
 
         private static void ConfigurePropertyFactory(IServiceCollection services)

--- a/PropertyInformationApi/V1/Mapper/EntityMapper.cs
+++ b/PropertyInformationApi/V1/Mapper/EntityMapper.cs
@@ -4,7 +4,7 @@ using PropertyInformationApi.V1.Infrastructure;
 
 namespace PropertyInformationApi.V1.Mapper
 {
-    public class EntityMapper
+    public class EntityMapper : IEntityMapper
     {
         private readonly IMapper _mapper;
 

--- a/PropertyInformationApi/V1/Mapper/IEntityMapper.cs
+++ b/PropertyInformationApi/V1/Mapper/IEntityMapper.cs
@@ -1,0 +1,10 @@
+using PropertyInformationApi.V1.Domain;
+using PropertyInformationApi.V1.Infrastructure;
+
+namespace PropertyInformationApi.V1.Mapper
+{
+    public interface IEntityMapper
+    {
+        HousingProperty ToDomain(UHProperty uhProperty);
+    }
+}

--- a/PropertyInformationApi/V1/UseCase/GetProperty.cs
+++ b/PropertyInformationApi/V1/UseCase/GetProperty.cs
@@ -8,8 +8,8 @@ namespace PropertyInformationApi.V1.UseCase
     public class GetProperty : IGetProperty
     {
         private readonly IPropertyGateway _gateway;
-        private readonly EntityMapper _mapper;
-        public GetProperty(IPropertyGateway gateway, EntityMapper mapper)
+        private readonly IEntityMapper _mapper;
+        public GetProperty(IPropertyGateway gateway, IEntityMapper mapper)
         {
             _gateway = gateway;
             _mapper = mapper;


### PR DESCRIPTION
## Describe this PR

### *What is the problem we're trying to solve*

`System.InvalidOperationException: Unable to resolve service for type 'PropertyInformationApi.V1.Mapper.EntityMapper' while attempting to activate 'PropertyInformationApi.V1.UseCase.GetProperty'.`

### *What changes have we introduced*

Refactored `EntityMapper` to be provided via dependency injection.

#### _Checklist_

- [x] Write `IEntityMapper.cs`
- [x] Register `IEntityMapper`/`Entitymapper` in `Startup.cs`

### *Follow up actions after merging PR*

Check whether the fix has worked in staging environment.