### PR TITLE
Stop ef core query timeout when endpoint is called without parameters

### DIFF
--- a/PropertyInformationApi/V1/Boundary/Request/GetPropertiesRequest.cs
+++ b/PropertyInformationApi/V1/Boundary/Request/GetPropertiesRequest.cs
@@ -1,6 +1,5 @@
 using Microsoft.AspNetCore.Mvc;
 using System.Collections.Generic;
-using System.Runtime.CompilerServices;
 
 namespace PropertyInformationApi.V1.Boundary.Request
 {

--- a/PropertyInformationApi/V1/Controllers/GetPropertyInformationController.cs
+++ b/PropertyInformationApi/V1/Controllers/GetPropertyInformationController.cs
@@ -62,7 +62,7 @@ namespace PropertyInformationApi.V1.Controllers
         /// <returns></returns>
         [HttpGet]
         [Produces("application/json")]
-        [ProducesResponseType(typeof(IEnumerable<HousingProperty>), 200)]
+        [ProducesResponseType(typeof(IList<HousingProperty>), 200)]
         [ProducesResponseType(typeof(BadRequestResult), 400)]
         [ProducesResponseType(typeof(NotFoundResult), 404)]
         public IActionResult GetMultipleByReference([FromQuery] GetPropertiesRequest propertyReferencesRequest)
@@ -72,7 +72,6 @@ namespace PropertyInformationApi.V1.Controllers
             try
             {
                 var useCaseResponse = _getProperties.Execute(propertyReferencesRequest);
-                if (useCaseResponse == null) return NotFound();
                 return Ok(useCaseResponse);
             }
             catch (InvalidQueryParameterException exception)

--- a/PropertyInformationApi/V1/Gateways/PropertyGateway.cs
+++ b/PropertyInformationApi/V1/Gateways/PropertyGateway.cs
@@ -18,7 +18,7 @@ namespace PropertyInformationApi.V1.Gateways
 
         public UHProperty GetPropertyByPropertyReference(string propertyReference)
         {
-            var response = _uhContext.UhProperties.FirstOrDefault(p => p.PropRef == propertyReference);
+            var response = _uhContext.UhProperties.Find(propertyReference);
             return response;
         }
 

--- a/PropertyInformationApi/V1/UseCase/GetPropertiesUseCase.cs
+++ b/PropertyInformationApi/V1/UseCase/GetPropertiesUseCase.cs
@@ -24,6 +24,10 @@ namespace PropertyInformationApi.V1.UseCase
 
         public IList<HousingProperty> Execute(GetPropertiesRequest request)
         {
+            //stop ef core query timeout
+            if (string.IsNullOrEmpty(request.Postcode) && string.IsNullOrEmpty(request.Address))
+                throw new InvalidQueryParameterException("Please check your query parameters");
+            //check postcode format is valid
             if (!_validatePostcode.Execute(request.Postcode))
                 throw new InvalidQueryParameterException("The postcode parameter does not have a valid format");
 


### PR DESCRIPTION
Make sure parameters are passed to query

## Link to JIRA ticket



## Describe this PR

### *What is the problem we're trying to solve*

query timeout for generated ef core query with no parameters

### *What changes have we introduced*

parameter validation

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [ ] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [ ] Checked all code for possible refactoring
- [ ] Code pipeline builds correctly

### *Follow up actions after merging PR*


